### PR TITLE
fix typo in error message for parsing errors

### DIFF
--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -964,13 +964,13 @@ impl MarionetteError {
                      ErrorStatus::UnknownError,
                      "Error value has no message").as_string(),
             ErrorStatus::UnknownError,
-            "Error messsage was not a string").into();
+            "Error message was not a string").into();
 
         let stacktrace = match data.find("stacktrace") {
             None | Some(&Json::Null) => None,
             Some(x) => Some(try_opt!(x.as_string(),
                                      ErrorStatus::UnknownError,
-                                     "Error messsage was not a string").into()),
+                                     "Error message was not a string").into()),
         };
         Ok(MarionetteError::new(status, message, stacktrace))
     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/64)
<!-- Reviewable:end -->
