### PR TITLE
Allow specifying arguments to the firefox binary through the firefox_args capability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ dependencies = [
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mozprofile 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mozrunner 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mozrunner 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "mozrunner"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ hyper = {version = "0.9", default-features = false}
 lazy_static = "0.1"
 log = "0.3"
 mozprofile = "0.2"
-mozrunner = "0.2"
+mozrunner = "0.3"
 regex = "0.1.47"
 rustc-serialize = "0.3.16"
 uuid = "0.1.18"


### PR DESCRIPTION
This must be an array of strings that will be interpreted as arguments to Firefox

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/65)
<!-- Reviewable:end -->
