### PR TITLE
cross-compile to windows on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,42 @@
-language: rust
-rust:
-  - stable
-  - beta
-  - nightly
+language: generic
+
 matrix:
-  allow_failures:
-    - rust: nightly
+  include:
+    - env: TARGET=i686-unknown-linux-gnu
+      addons:
+        apt:
+          packages:
+          - gcc-multilib
+    - env: TARGET=x86_64-unknown-linux-gnu
+    - env: TARGET=x86_64-unknown-linux-musl
+      dist: trusty
+      sudo: required
+      addons:
+        apt:
+          packages:
+          - musl-tools
+          - libbz2-dev
+    - env: TARGET=x86_64-pc-windows-gnu
+      dist: trusty
+      addons:
+        apt:
+          packages:
+          - gcc-mingw-w64
+          - gcc-mingw-w64-i686
+          - gcc-mingw-w64-x86-64
+          - binutils-mingw-w64-x86-64
+          - binutils-mingw-w64-i686
+          - libbz2-dev
+
+install:
+  - export PATH="$PATH:$HOME/.cargo/bin"
+  - curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=stable
+  - rustc -V
+  - cargo -V
+
+script:
+  - bash ci.sh
+
+branches:
+  only:
+    - master

--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,74 @@
+set -ex
+
+# Add provided target to current Rust toolchain if it is not already
+# the default or installed.
+rustup_target_add() {
+	if ! rustup target list | grep -E "$1 \((default|installed)\)"
+	then
+		rustup target add $1
+	fi
+}
+
+# Configure rustc target for cross compilation.  Provided with a build
+# target, this will determine which linker to use for cross compilation.
+cargo_config() {
+	local prefix
+
+	case "$TARGET" in
+	aarch64-unknown-linux-gnu)
+		prefix=aarch64-linux-gnu
+		;;
+	arm*-unknown-linux-gnueabihf)
+		prefix=arm-linux-gnueabihf
+		;;
+	arm-unknown-linux-gnueabi)
+		prefix=arm-linux-gnueabi
+		;;
+	mipsel-unknown-linux-musl)
+		prefix=mipsel-openwrt-linux
+		;;
+	x86_64-pc-windows-gnu)
+		prefix=x86_64-w64-mingw32
+		;;
+	*)
+		return
+		;;
+	esac
+
+	mkdir -p ~/.cargo
+	cat >>~/.cargo/config <<EOF
+[target.$TARGET]
+linker = "$prefix-gcc"
+EOF
+}
+
+# Build current crate and print file type information.
+cargo_build() {
+	cargo build --target $1
+
+	if [[ "$1" =~ "windows" ]]
+	then
+		file target/$1/debug/geckodriver.exe
+	else
+		file target/$1/debug/geckodriver
+	fi
+}
+
+# Run current crate's tests if the current system supports it.
+cargo_test() {
+	if echo "$1" | grep -E "(i686|x86_64)-unknown-linux-(gnu|musl)"
+	then
+		cargo test --target $1
+	else
+		>&2 echo "not running tests on $1"
+	fi
+}
+
+main() {
+	rustup_target_add $TARGET
+	cargo_config $TARGET
+	cargo_build $TARGET
+	cargo_test $TARGET
+}
+
+main


### PR DESCRIPTION
This patch makes it possible to cross-compile geckodriver on Linux with
glibc and musl, producing dynamic- and static binaries respectively,
as well as Windows. I have confirmed that the Windows binaries run.

PR #70 addresses a regression in the webdriver library crate to build the
cookie crate without OpenSSL support, and is a prerequisite for this. I
noticed that it is possible to build with OpenSSL with a bit more effort,
should we want to in the future, but this adds significant complexity
and build time.

Fixes #71.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/73)
<!-- Reviewable:end -->
