### PR TITLE
Add -v flag to optionally increase Gecko verbosity

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ macro_rules! println_stderr {
 macro_rules! err {
     ($($arg:tt)*) => { {
         let prog = env::args().next().unwrap();
-        println_stderr!("{}: error: {}", prog, $($arg)*);
+        println_stderr!("{}: error: {}", prog, format_args!($($arg)*));
         process::exit(64);
     } }
 }
@@ -135,7 +135,7 @@ fn main() {
     } else if opts.log_level.len() > 0 {
         match LogLevel::from_str(&opts.log_level) {
             Ok(l) => Some(l),
-            Err(_) => { err!(format_args!("unknown log level: {}", opts.log_level)); },
+            Err(_) => { err!("unknown log level: {}", opts.log_level); },
         }
     } else {
         match opts.verbosity {

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,9 +139,9 @@ fn main() {
         }
     } else {
         match opts.verbosity {
+            0 => None,
             1 => Some(LogLevel::Debug),
-            2 => Some(LogLevel::Trace),
-            _ => None
+            _ => Some(LogLevel::Trace),
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,7 @@ fn main() {
         err!("conflicting logging- and verbosity arguments");
     } else if opts.log_level.len() > 0 {
         match LogLevel::from_str(&opts.log_level) {
-            Ok(l) => Some(l),
+            Ok(level) => Some(level),
             Err(_) => { err!("unknown log level: {}", opts.log_level); },
         }
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,8 +193,13 @@ mod tests {
             required: required
         };
 
-        let handler = MarionetteHandler::new(
-            MarionetteSettings::new(2828u16, BrowserLauncher::None, false));
+        let settings = MarionetteSettings {
+            port: 2828,
+            launcher: BrowserLauncher::None,
+            e10s: false,
+            log_level: None,
+        };
+        let handler = MarionetteHandler::new(settings);
 
         let mut gecko_profile = handler.load_profile(&capabilities).unwrap().unwrap();
         handler.set_prefs(&mut gecko_profile, true).unwrap();


### PR DESCRIPTION
Introduces a cumulative -v flag where a single instance mean INFO level
and above are shown and two mean TRACE. The log levels are defined in
Log.jsm in the Gecko toolkit.

MarionetteSettings gains a new `verbosity' property that if undefined
uses the defaults in Gecko. This means we are no longer requiring the
marionette.logging preference to be set.

The defaults in Gecko are INFO for optimised builds and DEBUG for
debug builds.

Fixes #89.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/103)
<!-- Reviewable:end -->
