### PR TITLE
Disable autofill of forms by default

### DIFF
--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -66,7 +66,7 @@ lazy_static! {
         ("browser.tabs.remote.autostart.2", Pref::new(false)),
     ];
 
-    pub static ref FIREFOX_DEFAULT_PREFERENCES: [(&'static str, Pref); 44] = [
+    pub static ref FIREFOX_DEFAULT_PREFERENCES: [(&'static str, Pref); 45] = [
         ("app.update.auto", Pref::new(false)),
         ("app.update.enabled", Pref::new(false)),
         ("browser.displayedE10SPrompt.1", Pref::new(5)),
@@ -105,6 +105,7 @@ lazy_static! {
         ("security.warn_submit_insecure", Pref::new(false)),
         ("security.warn_viewing_mixed", Pref::new(false)),
         ("security.warn_viewing_mixed.show_once", Pref::new(false)),
+        ("signon.autofillForms", Pref::new(false)),
         ("signon.rememberSignons", Pref::new(false)),
         ("startup.homepage_welcome_url", Pref::new("about:blank")),
         ("toolkit.networkmanager.disable", Pref::new(true)),


### PR DESCRIPTION
I experienced issues when testing login/logout scenarios with geckodriver. Firefox was using credentials of previous entered users when login in the third time in one test case. Disabling the autofill of forms fixed it. Seems like chromedriver disables autofill by default too, because with the same test I had no problems there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/134)
<!-- Reviewable:end -->
