### PR TITLE
Replace argparse with clap for arguments parsing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,14 +2,14 @@
 name = "geckodriver"
 version = "0.9.0"
 dependencies = [
- "argparse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mozprofile 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mozrunner 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "webdriver 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -21,7 +21,7 @@ name = "advapi32-sys"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -34,8 +34,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "argparse"
-version = "0.2.1"
+name = "ansi_term"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -44,7 +49,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bzip2-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -53,7 +58,21 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clap"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term_size 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -67,11 +86,11 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -79,7 +98,7 @@ name = "flate2"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -103,7 +122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -136,7 +155,7 @@ name = "kernel32-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -145,7 +164,7 @@ name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -154,7 +173,7 @@ name = "ktmw32-sys"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -170,7 +189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -188,7 +207,7 @@ name = "memchr"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -205,7 +224,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -235,7 +254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -243,7 +262,7 @@ name = "num_cpus"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -256,24 +275,24 @@ name = "rand"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.1.71"
+version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -304,6 +323,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "tempdir"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,12 +336,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_size"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread-id"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -334,8 +366,8 @@ version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -370,6 +402,11 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "url"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,21 +430,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "vec_map"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "webdriver"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "winapi"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -424,7 +466,7 @@ dependencies = [
  "kernel32-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ktmw32-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/jgraham/wires"
 license = "MPL-2.0"
 
 [dependencies]
-argparse = "0.2.1"
+clap = "2.6"
 env_logger = "0.3.2"
 hyper = {version = "0.9", default-features = false}
 lazy_static = "0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
 #[macro_use]
+extern crate clap;
+#[macro_use]
 extern crate log;
 #[macro_use]
 extern crate lazy_static;
-extern crate argparse;
 extern crate env_logger;
 extern crate hyper;
 extern crate mozprofile;
@@ -13,16 +14,14 @@ extern crate rustc_serialize;
 extern crate webdriver;
 extern crate zip;
 
+use clap::{App, Arg};
+use marionette::{MarionetteHandler, LogLevel, MarionetteSettings, extension_routes};
 use std::borrow::ToOwned;
 use std::io::Write;
 use std::net::{SocketAddr, IpAddr};
 use std::path::PathBuf;
 use std::str::FromStr;
-
-use argparse::{ArgumentParser, IncrBy, StoreTrue, Store, StoreOption};
 use webdriver::server::start;
-
-use marionette::{MarionetteHandler, LogLevel, MarionetteSettings, extension_routes};
 
 macro_rules! try_opt {
     ($expr:expr, $err_type:expr, $err_msg:expr) => ({
@@ -42,129 +41,102 @@ enum ExitCode {
     Usage = 64,
 }
 
-struct Options {
-    binary: Option<String>,
-    webdriver_host: String,
-    webdriver_port: u16,
-    marionette_port: Option<u16>,
-    connect_existing: bool,
-    e10s: bool,
-    log_level: String,
-    verbosity: u8,
-    version: bool,
-}
-
-fn parse_args() -> Options {
-    let mut opts = Options {
-        binary: None,
-        webdriver_host: "127.0.0.1".to_owned(),
-        webdriver_port: 4444u16,
-        marionette_port: None,
-        connect_existing: false,
-        e10s: false,
-        log_level: "".to_owned(),
-        verbosity: 0,
-        version: false,
-    };
-
-    {
-        let mut parser = ArgumentParser::new();
-        parser.set_description("WebDriver to Marionette proxy.");
-
-        parser.refer(&mut opts.binary)
-            .add_option(&["-b", "--binary"], StoreOption,
-                        "Path to the Firefox binary");
-        parser.refer(&mut opts.webdriver_host)
-            .add_option(&["--webdriver-host"], Store,
-                        "Host to run webdriver server on");
-        parser.refer(&mut opts.webdriver_port)
-            .add_option(&["--webdriver-port"], Store,
-                        "Port to run webdriver on");
-        parser.refer(&mut opts.marionette_port)
-            .add_option(&["--marionette-port"], StoreOption,
-                        "Port to run marionette on");
-        parser.refer(&mut opts.connect_existing)
-            .add_option(&["--connect-existing"], StoreTrue,
-                        "Connect to an existing firefox process");
-        parser.refer(&mut opts.e10s)
-            .add_option(&["--e10s"], StoreTrue,
-                        "Load Firefox with an e10s profile");
-        parser.refer(&mut opts.log_level)
-            .add_option(&["--log"], Store,
-            "Desired verbosity level of Gecko \
-            (fatal, error, warn, info, config, debug, trace)")
-            .metavar("LEVEL");
-        parser.refer(&mut opts.verbosity)
-            .add_option(&["-v"], IncrBy(1),
-            "Shorthand to increase verbosity of output \
-            to include debug messages with -v, \
-            and trace messages with -vv");
-        parser.refer(&mut opts.version)
-            .add_option(&["--version"], StoreTrue,
-            "Show version and copying information.");
-
-        parser.parse_args_or_exit();
-    }
-
-    opts
-}
-
-fn print_version() {
-    let version = option_env!("CARGO_PKG_VERSION").unwrap_or("unknown");
-
-    println!(r#"geckodriver v{}
-https://github.com/mozilla/geckodriver
+fn app<'a, 'b>() -> App<'a, 'b> {
+    App::new("geckodriver")
+        .about("WebDriver implementation for Firefox.")
+        .version(crate_version!())
+        .after_help("The source is available at https://github.com/mozilla/geckodriver
 
 This program is subject to the terms of the Mozilla Public License 2.0.
-You can obtain a copy of the license at https://mozilla.org/MPL/2.0/."#,
-             version);
+You can obtain a copy of the license at https://mozilla.org/MPL/2.0/.
+")
+        .arg(Arg::with_name("webdriver_host")
+             .long("host")
+             .help("Host ip to use for WebDriver server (default: 127.0.0.1)")
+             .takes_value(true))
+        .arg(Arg::with_name("webdriver_port")
+             .short("p")
+             .long("port")
+             .help("Port to use for WebDriver server (default: 4444)")
+             .takes_value(true))
+        .arg(Arg::with_name("binary")
+             .short("b")
+             .long("binary")
+             .help("Path to the Firefox binary, if no binary capability provided")
+             .takes_value(true))
+        .arg(Arg::with_name("marionette_port")
+             .long("marionette-port")
+             .help("Port to use to connect to gecko (default: random free port)")
+             .takes_value(true))
+        .arg(Arg::with_name("connect_existing")
+             .long("connect-existing")
+             .requires("marionette-port")
+             .help("Connect to an existing Firefox instance"))
+        .arg(Arg::with_name("--no-e10s")
+             .long("no_e10s")
+             .help("Start Firefox without e10s enabled"))
+        .arg(Arg::with_name("verbosity")
+             .short("v")
+             .multiple(true)
+             .conflicts_with("log_level")
+             .help("Set the level of verbosity. Pass once for DEBUG level logging and twice for TRACE level logging"))
+        .arg(Arg::with_name("log_level")
+             .long("log")
+             .takes_value(true)
+             .possible_values(
+                 &["fatal", "error", "warn", "info", "config", "debug", "trace"])
+             .help("Set internal Gecko log level"))
 }
 
-fn print_usage(reason: &str) {
-    let prog = std::env::args().next().unwrap();
-    let _ = writeln!(&mut ::std::io::stderr(), "{}: error: {}", prog, reason);
+fn print_err(reason: &str) {
+    let _ = writeln!(&mut ::std::io::stderr(), "\n{}", reason);
 }
 
 fn run() -> ProgramResult {
-    let opts = parse_args();
+    let matches = app().get_matches();
 
-    if opts.version {
-        print_version();
-        return Ok(())
-    }
-
-    let host = &opts.webdriver_host[..];
-    let port = opts.webdriver_port;
+    let host = matches.value_of("webdriver_host").unwrap_or("127.0.0.1");
+    let port = match u16::from_str(matches.value_of("webdriver_port").unwrap_or("4444")) {
+        Ok(x) => x,
+        Err(_) => return Err((ExitCode::Usage, "Invalid WebDriver port".to_owned())),
+    };
     let addr = match IpAddr::from_str(host) {
         Ok(addr) => SocketAddr::new(addr, port),
         Err(_) => return Err((ExitCode::Usage, "invalid host address".to_owned())),
     };
 
-    // overrides defaults in Gecko
-    // which are info for optimised builds
-    // and debug for debug builds
-    let log_level = if opts.log_level.len() > 0 && opts.verbosity > 0 {
-        return Err((ExitCode::Usage, "conflicting logging- and verbosity arguments".to_owned()))
-    } else if opts.log_level.len() > 0 {
-        match LogLevel::from_str(&opts.log_level) {
-            Ok(level) => Some(level),
-            Err(_) => return Err((ExitCode::Usage, format!("unknown log level: {}", opts.log_level))),
-        }
-    } else {
-        match opts.verbosity {
-            0 => None,
-            1 => Some(LogLevel::Debug),
-            _ => Some(LogLevel::Trace),
-        }
+    let binary = matches.value_of("binary").map(|x| PathBuf::from(x));
+
+    let marionette_port = match matches.value_of("marionette_port") {
+        Some(x) => match u16::from_str(x) {
+            Ok(x) => Some(x),
+            Err(_) => return Err((ExitCode::Usage, "Invalid marionette port".to_owned())),
+        },
+        None => None
     };
 
+        // overrides defaults in Gecko
+    // which are info for optimised builds
+    // and debug for debug builds
+    let log_level =
+        if matches.is_present("log_level") {
+            LogLevel::from_str(matches.value_of("log_level").unwrap()).ok()
+        } else {
+            match matches.occurrences_of("v") {
+                0 => None,
+                1 => Some(LogLevel::Debug),
+                _ => Some(LogLevel::Trace),
+            }
+        };
+
     let settings = MarionetteSettings {
-        port: opts.marionette_port,
-        binary: opts.binary.map(|x| PathBuf::from(x)),
-        connect_existing: opts.connect_existing,
-        e10s: opts.e10s,
-        log_level: log_level
+        port: marionette_port,
+        binary: binary,
+        connect_existing: matches.is_present("connect_existing"),
+        e10s: !matches.is_present("no_e10s"),
+        log_level: log_level,
     };
+
     start(addr, MarionetteHandler::new(settings), extension_routes());
 
     Ok(())
@@ -176,7 +148,7 @@ fn main() {
     let exit_code = match run() {
         Ok(_) => ExitCode::Ok,
         Err((exit_code, reason)) => {
-            print_usage(&reason.to_string());
+            print_err(&reason.to_string());
             exit_code
         },
     };


### PR DESCRIPTION
This appears to be more popular in the Rust community and doesn't seem to
be much worse, so it's probably a safer choice going forward.