### PR TITLE
Change the format used for capabilities.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,8 +12,8 @@ dependencies = [
  "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "webdriver 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zip 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webdriver 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zip 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -430,7 +430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "webdriver"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.1.18"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bzip2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ mozrunner = "^0.3.1"
 regex = "0.1.47"
 rustc-serialize = "0.3.16"
 uuid = "0.1.18"
-webdriver = "0.12"
+webdriver = "0.13"
 zip = "0.1.16"
 
 [dependencies.clap]

--- a/README.md
+++ b/README.md
@@ -36,29 +36,46 @@ the more bug fixes and features.
 
 ## Firefox capabilities
 
-**Note**: The names of these capabilities will change in a future release to better match
-the precedent set by ChromeDriver.
+geckodriver supports a capability named `firefoxOptions` which takes
+Firefox-specific preference values. This must be a dictionary and may
+contain any of the following fields:
 
-geckodriver supports a couple of non-standard capabilities
-to customise and configure a Firefox session:
-
-<dl>
- <dt><code>firefox_binary</code>
- <dd>Set to full path of the Firefox binary,
-  e.g. <i>/usr/bin/firefox</i> or <i>/Applications/Firefox.app/Contents/MacOS/firefox</i>,
-  to select which custom browser binary to use.
-  If left undefined geckodriver will attempt
-  to deduce the default location of Firefox
-  on the current system.
-
- <dt><code>firefox_profile</code>
- <dd>For each session, geckodriver creates a new temporary profile by default.
-  To set custom preferences or use an add-on/extension,
-  you may want to provide a custom profile.
-  A profile can be sent across the wire protocol
-  by setting this capability to its path
-  on the local filesystem.
-</dl>
+<table>
+    <thead>
+        <tr>
+            <th>Name
+            <th>Type
+            <th>Default
+            <th>Description
+        </tr>
+    </thead>
+    <tr>
+        <td><code>binary</code>
+        <td>String
+        <td>Taken from geckodriver command line or system defaults.
+        <td>Absolute path of the Firefox binary,
+    e.g. <code>/usr/bin/firefox</code> or <code>/Applications/Firefox.app/Contents/MacOS/firefox</code>,
+    to select which custom browser binary to use.
+    If left undefined geckodriver will attempt
+    to deduce the default location of Firefox
+    on the current system.
+    <tr>
+        <td><code>args</code>
+        <td>Array of strings
+        <td>
+        <td>Command line arguments to pass to the
+ Firefox binary. These must include the leading `--` where required
+ e.g. `["--devtools"]`.
+    </tr>
+    <tr>
+        <td><code>profile</code>
+        <td>String
+        <td>New empty profile
+        <td>Base64-encoded zip of a profile directory
+ to use as the profile for the Firefox instance. This may be used to
+ e.g. install extensions or custom certificates.
+    </tr>
+</table>
 
 ## Building
 
@@ -73,7 +90,7 @@ ensure you do a compilation with optimisations:
 Or if you want a non-optimised binary for debugging:
 
     % cargo build
- 
+
 ## Usage
 
 Usage steps are [documented on MDN](https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver),


### PR DESCRIPTION
Put all the Firefox-specific configuration items into a key named
firefoxOptions, which much be an object (if present) and may have
subkeys binary, args and profile.

This object is not sent to marionette for efficiency reasons (the
profile in particular may be very large) and the used values do not
get returned to the local end.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/161)
<!-- Reviewable:end -->
