### PR TITLE
Remove e10s command line option.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -79,9 +79,6 @@ fn app<'a, 'b>() -> App<'a, 'b> {
              .long("connect-existing")
              .requires("marionette_port")
              .help("Connect to an existing Firefox instance"))
-        .arg(Arg::with_name("no_e10s")
-             .long("--no-e10s")
-             .help("Start Firefox without multiprocess support (e10s) enabled"))
         .arg(Arg::with_name("verbosity")
              .short("v")
              .multiple(true)
@@ -141,7 +138,6 @@ fn run() -> ProgramResult {
         port: marionette_port,
         binary: binary,
         connect_existing: matches.is_present("connect_existing"),
-        e10s: !matches.is_present("no_e10s"),
         log_level: log_level,
     };
 
@@ -203,7 +199,6 @@ mod tests {
             port: None,
             binary: None,
             connect_existing: false,
-            e10s: false,
             log_level: None,
         };
         let handler = MarionetteHandler::new(settings);

--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -57,15 +57,6 @@ use zip;
 const DEFAULT_HOST: &'static str = "localhost";
 
 lazy_static! {
-    pub static ref E10S_PREFERENCES: [(&'static str, Pref); 1] = [
-        ("browser.tabs.remote.autostart", Pref::new(true)),
-    ];
-
-    pub static ref NON_E10S_PREFERENCES: [(&'static str, Pref); 2] = [
-        ("browser.tabs.remote.autostart", Pref::new(false)),
-        ("browser.tabs.remote.autostart.2", Pref::new(false)),
-    ];
-
     pub static ref FIREFOX_DEFAULT_PREFERENCES: [(&'static str, Pref); 45] = [
         ("app.update.auto", Pref::new(false)),
         ("app.update.enabled", Pref::new(false)),
@@ -284,9 +275,6 @@ pub struct MarionetteSettings {
     pub binary: Option<PathBuf>,
     pub connect_existing: bool,
 
-    /// Enable or disable Electrolysis, or multi-processing, in Gecko.
-    pub e10s: bool,
-
     /// Optionally increase Marionette's verbosity by providing a log
     /// level. The Gecko default is LogLevel::Info for optimised
     /// builds and LogLevel::Debug for debug builds.
@@ -299,7 +287,6 @@ pub struct MarionetteHandler {
     connect_existing: bool,
     browser: Option<FirefoxRunner>,
     port: Option<u16>,
-    e10s: bool,
     log_level: Option<LogLevel>,
 }
 
@@ -311,7 +298,6 @@ impl MarionetteHandler {
             connect_existing: settings.connect_existing,
             browser: None,
             port: settings.port,
-            e10s: settings.e10s,
             log_level: settings.log_level,
         }
     }
@@ -385,11 +371,6 @@ impl MarionetteHandler {
         prefs.insert_slice(&FIREFOX_REQUIRED_PREFERENCES[..]);
         if !custom_profile {
             prefs.insert_slice(&FIREFOX_DEFAULT_PREFERENCES[..]);
-            if self.e10s {
-                prefs.insert_slice(&E10S_PREFERENCES[..]);
-            } else {
-                prefs.insert_slice(&NON_E10S_PREFERENCES[..]);
-            }
         };
         if let Some(ref l) = self.log_level {
             prefs.insert("marionette.logging", Pref::new(l.to_string()));


### PR DESCRIPTION
E10s support will now match the browser default. Users wishing to change
this default should pass prefs in with the capabilities as required.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/163)
<!-- Reviewable:end -->
