### PR TITLE
Describe overloaded firefox_profile caps functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ to customise and configure a Firefox session:
   you may want to provide a custom profile.
   A profile can be sent across the wire protocol
   by setting this capability to its path
-  on the local filesystem.
+  on the local filesystem. The previous behavior of 
+  accepting a profile directory that has been zipped
+  and base64-encoded is also supported.
 </dl>
 
 ## Building


### PR DESCRIPTION
I was surprised to read that `firefox_profile` accepted a path on the local filesystem in the README, instead of accepting the zipped, base64 directory like the old `.xpi` extension used to, and also how the remote driver treats the `firefox_profile` cap. So I checked and it does of course handle the [zipped base64 directory method](
https://github.com/mozilla/geckodriver/blob/da1bee2b2db981646730fccd09650f87b0cbf8fe/src/marionette.rs#L408). I thought it might be useful to indicate that the filesystem-path behavior overloads the cap, instead of replacing the zipped/b64 functionality.

But if this doesn't seem to confusing to y'all, feel free to reject. And, thanks for all the hard work on `geckodriver`!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/164)
<!-- Reviewable:end -->
