### PR TITLE
Disable pop-up blocker in the default profile.

### DIFF
--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -57,7 +57,7 @@ use zip;
 const DEFAULT_HOST: &'static str = "localhost";
 
 lazy_static! {
-    pub static ref FIREFOX_DEFAULT_PREFERENCES: [(&'static str, Pref); 45] = [
+    pub static ref FIREFOX_DEFAULT_PREFERENCES: [(&'static str, Pref); 46] = [
         ("app.update.auto", Pref::new(false)),
         ("app.update.enabled", Pref::new(false)),
         ("browser.displayedE10SPrompt.1", Pref::new(5)),
@@ -83,6 +83,7 @@ lazy_static! {
         ("datareporting.policy.dataSubmissionEnabled", Pref::new(false)),
         ("datareporting.policy.dataSubmissionPolicyAccepted", Pref::new(false)),
         ("devtools.errorconsole.enabled", Pref::new(true)),
+        ("dom.disable_open_during_load", Pref::new(false)),
         ("dom.ipc.reportProcessHangs", Pref::new(false)),
         ("focusmanager.testmode", Pref::new(true)),
         ("security.fileuri.origin_policy", Pref::new(3)),


### PR DESCRIPTION
Seems like a useful default preference.

I'm happy to just always set this in a profile capability if you'd rather users do it that way. I only suggest this because in the Java and Python client bindings (and probably others), if you construct a new FirefoxProfile(), it contains this pref by default, which means that the popup blocker is enabled if you omit the `firefox_profile` capability, but disabled if you pass a profile created with the default constructor and no further modifications.

(But perhaps that should just be the client's problem, in the end.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/165)
<!-- Reviewable:end -->
