### PR TITLE
Log listening host and port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
  "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "webdriver 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webdriver 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -430,7 +430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "webdriver"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ mozrunner = "^0.3.1"
 regex = "0.1.47"
 rustc-serialize = "0.3.16"
 uuid = "0.1.18"
-webdriver = "0.13"
+webdriver = "0.14"
 zip = "0.1.16"
 
 [dependencies.clap]


### PR DESCRIPTION
These patches make use of the return value in webdriver::server::start introduced in webdriver-rust 0.14 by printing the host and port to stderr after we bind and the HTTPD has spun up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/218)
<!-- Reviewable:end -->
