### PR TITLE
Rename firefoxOptions to moz:firefoxOptions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,14 +7,14 @@ All notable changes to this program is documented in this file.
 ### Added
 - Introduced continous integration builds for Windows 32-bit binaries
 - Added new extension commands for finding an element’s anonymous children and querying its attributes; accessible through the `/session/{sessionId}/moz/xbl/{elementId}/anonymous_children` to return all anonymous children and `/session/{sessionId}/moz/xbl/{elementId}/anonymous_by_attribute` to return an anonymous element by a name and attribute query
-- Introduced a `firefoxOptions` capability to customise a Firefox session:
+- Introduced a `moz:firefoxOptions` capability to customise a Firefox session:
   - The `binary`, `args`, and `profile` entries on this dictionary is equivalent to the old `firefox_binary`, `firefox_args`, and `firefox_profile` capabilities, which have now all been removed
   - The `log` capability takes a dictionary such as `{log: "trace"}` to enable trace level verbosity in Gecko
   - The `prefs` capability lets you define Firefox preferences through capabilities
 - Re-introduced the `--webdriver-port` argument as a hidden alias to `--port`
 
 ### Changed
-- `firefox_binary`, `firefox_args`, and `firefox_profile` capabilities removed in favour of the `firefoxOptions` dictionary detailed above and in the README
+- `firefox_binary`, `firefox_args`, and `firefox_profile` capabilities removed in favour of the `moz:firefoxOptions` dictionary detailed above and in the README
 - Removed `--no-e10s` flag, and geckodriver will from now rely on the Firefox default multiprocessing settings (override using preferences)
 - Disable pop-up blocker in the default profile by @juangj
 - Changed Rust compiler version to 1.12 (beta) temporarily because of [trouble linking Musl binaries](https://github.com/rust-lang/rust/issues/34978)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ the more bug fixes and features.
 
 ## Firefox capabilities
 
-geckodriver supports a capability named `firefoxOptions` which takes
+geckodriver supports a capability named `moz:firefoxOptions` which takes
 Firefox-specific preference values. This must be a dictionary and may
 contain any of the following fields:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,7 +224,7 @@ mod tests {
         let mut capabilities = capabilities();
         let mut firefox_options: BTreeMap<String, Json> = BTreeMap::new();
         firefox_options.insert("profile".into(), encoded_profile);
-        capabilities.required.insert("firefoxOptions".into(), Json::Object(firefox_options));
+        capabilities.required.insert("moz:firefoxOptions".into(), Json::Object(firefox_options));
 
         let options = FirefoxOptions::from_capabilities(&mut capabilities).unwrap();
         let mut profile = options.profile.unwrap();
@@ -246,7 +246,7 @@ mod tests {
         let mut prefs: BTreeMap<String, Json> = BTreeMap::new();
         prefs.insert("browser.display.background_color".into(), Json::String("#00ff00".into()));
         firefox_options.insert("prefs".into(), Json::Object(prefs));
-        capabilities.required.insert("firefoxOptions".into(), Json::Object(firefox_options));
+        capabilities.required.insert("moz:firefoxOptions".into(), Json::Object(firefox_options));
 
 
         let options = FirefoxOptions::from_capabilities(&mut capabilities).unwrap();

--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -311,17 +311,17 @@ pub struct FirefoxOptions {
     pub profile: Option<Profile>,
     pub args: Option<Vec<String>>,
     pub log: LogOptions,
-    pub prefs: Vec<(String, Pref)>
+    pub prefs: Vec<(String, Pref)>,
 }
 
 impl FirefoxOptions {
     pub fn from_capabilities(capabilities: &mut NewSessionParameters) -> WebDriverResult<FirefoxOptions> {
-        if let Some(options) = capabilities.consume("firefoxOptions") {
+        if let Some(options) = capabilities.consume("moz:firefoxOptions") {
             let firefox_options = try!(options
                                        .as_object()
                                        .ok_or(WebDriverError::new(
                                            ErrorStatus::InvalidArgument,
-                                           "'firefoxOptions' capability was not an object")));
+                                           "'moz:firefoxOptions' capability was not an object")));
             let binary = try!(FirefoxOptions::load_binary(&firefox_options));
             let profile = try!(FirefoxOptions::load_profile(&firefox_options));
             let args = try!(FirefoxOptions::load_args(&firefox_options));
@@ -484,7 +484,7 @@ impl MarionetteHandler {
                           .ok_or(WebDriverError::new(ErrorStatus::UnknownError,
                                                      "Expected browser binary location, \
                                                       but unable to find binary in default location, \
-                                                      no 'firefoxOptions.binary' capability provided, \
+                                                      no 'moz:firefoxOptions.binary' capability provided, \
                                                       and no binary flag set on the command line")));
 
         let custom_profile = options.profile.is_some();


### PR DESCRIPTION
See https://github.com/w3c/webdriver/pull/343 for further details on
extension capabilities.

Fixes #250.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/251)
<!-- Reviewable:end -->
