### PR TITLE
Make it possible to override Rust toolchain for individual configs in CI

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ print_versions() {
 
 rustup_install() {
     export PATH="$PATH:$HOME/.cargo/bin"
-    curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=beta
+    curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=$1
 }
 
 # Add provided target to current Rust toolchain if it is not already
@@ -122,12 +122,14 @@ package_binary() {
 }
 
 main() {
+    TOOLCHAIN=${TOOLCHAIN:=beta}
+
     if [ ! -z "$USE_DOCKER" ]
     then
         setup_docker
         print_versions
     else
-        rustup_install
+        rustup_install $TOOLCHAIN
         print_versions
         rustup_target_add $TARGET
     fi

--- a/build.sh
+++ b/build.sh
@@ -58,6 +58,8 @@ cargo_config() {
 [target.$TARGET]
 linker = "$prefix-gcc"
 EOF
+
+    cat ~/.cargo/config
 }
 
 # Build current crate for given target and print file type information.

--- a/build.sh
+++ b/build.sh
@@ -45,6 +45,9 @@ cargo_config() {
     x86_64-pc-windows-gnu)
         prefix=x86_64-w64-mingw32
         ;;
+    i686-pc-windows-gnu)
+        prefix=i686-w64-mingw32
+        ;;
     *)
         return
         ;;


### PR DESCRIPTION
This change makes it possible to set the TOOLCHAIN output variable which
will override the default toolchain defined in build.sh.  If TOOLCHAIN
is not defined it picks the default, which is currently `beta`.

The change should not affect the current build configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/253)
<!-- Reviewable:end -->
