### PR TITLE
Encode more response as "value" responses

### DIFF
--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -41,8 +41,7 @@ use webdriver::command::{
     GetCookieParameters, AddCookieParameters, TimeoutsParameters,
     TakeScreenshotParameters, WindowPositionParameters};
 use webdriver::response::{
-    WebDriverResponse, NewSessionResponse, ValueResponse, WindowSizeResponse,
-    WindowPositionResponse, ElementRectResponse, CookieResponse, Cookie};
+    WebDriverResponse, NewSessionResponse, ValueResponse, CookieResponse, Cookie};
 use webdriver::common::{
     Date, Nullable, WebElement, FrameId, ELEMENT_KEY};
 use webdriver::error::{ErrorStatus, WebDriverError, WebDriverResult};
@@ -592,8 +591,10 @@ impl MarionetteSession {
                              "Failed to find height field").as_u64(),
                     ErrorStatus::UnknownError,
                     "Failed to interpret width as integer");
-
-                WebDriverResponse::WindowSize(WindowSizeResponse::new(width, height))
+                let mut data = BTreeMap::new();
+                data.insert("width".to_owned(), width.to_json());
+                data.insert("height".to_owned(), height.to_json());
+                WebDriverResponse::Generic(ValueResponse::new(Json::Object(data)))
             },
             GetWindowPosition => {
                 let x = try_opt!(
@@ -610,7 +611,10 @@ impl MarionetteSession {
                     ErrorStatus::UnknownError,
                     "Failed to interpret y as integer");
 
-                WebDriverResponse::WindowPosition(WindowPositionResponse::new(x, y))
+                let mut data = BTreeMap::new();
+                data.insert("x".to_owned(), x.to_json());
+                data.insert("y".to_owned(), y.to_json());
+                WebDriverResponse::Generic(ValueResponse::new(Json::Object(data)))
             },
             GetElementRect(_) => {
                 let x = try_opt!(
@@ -641,7 +645,12 @@ impl MarionetteSession {
                     ErrorStatus::UnknownError,
                     "Failed to interpret width as float");
 
-                WebDriverResponse::ElementRect(ElementRectResponse::new(x, y, width, height))
+                let mut data = BTreeMap::new();
+                data.insert("x".to_owned(), x.to_json());
+                data.insert("y".to_owned(), y.to_json());
+                data.insert("width".to_owned(), width.to_json());
+                data.insert("height".to_owned(), height.to_json());
+                WebDriverResponse::Generic(ValueResponse::new(Json::Object(data)))
             },
             GetCookies => {
                 let cookies = try!(self.process_cookies(&resp.result));


### PR DESCRIPTION
The WG recently agreed that responses should always contain
the returned value in a "value" property. This makes that
change for most commands that don't already do this, other
than those dealing with cookies.

An alternative implementation would be to modify the response
objects in the underlying webdriver library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/263)
<!-- Reviewable:end -->
