### PR TITLE
Add musl-tools dependency for i686-unknown-linux-musl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,14 @@ matrix:
         - TARGET=i686-unknown-linux-musl
         - NAME=linux32
         - EXT=tar.gz
+      dist: trusty
+      sudo: required
       addons:
         apt:
           packages: &i686
+          - musl-tools
           - gcc-multilib
+          - libbz2-dev
     - os: linux
       env:
         - TARGET=x86_64-pc-windows-gnu


### PR DESCRIPTION
This fixes the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/390)
<!-- Reviewable:end -->
