### PR TITLE
Update README.md to highlight no Windows XP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,46 @@ and enable verbose logging:
 }
 ```
 
+## Usage
+
+Usage steps are [documented on MDN](https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver),
+but the gist of it is this:
+
+	% geckodriver -b /usr/bin/firefox
+
+Or if you’re on Mac:
+
+	% geckodriver -b /Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin
+
+You may also see all flags and options
+available in geckodriver by viewing the help message:
+
+	% geckodriver -h
+	geckodriver 0.11.1
+	WebDriver implementation for Firefox.
+
+	USAGE:
+	    geckodriver [FLAGS] [OPTIONS]
+
+	FLAGS:
+	        --connect-existing    Connect to an existing Firefox instance
+	    -h, --help                Prints help information
+	    -v                        Log level verbosity (-v for debug and -vv for
+	                              trace level)
+	    -V, --version             Prints version and copying information
+
+	OPTIONS:
+	    -b, --binary <BINARY>           Path to the Firefox binary
+	        --log <LEVEL>
+	            Set Gecko log level [values: fatal, error, warn, info, config,
+	            debug, trace]
+	        --marionette-port <PORT>
+	            Port to use to connect to Gecko (default: random free port)
+	        --host <HOST>
+	            Host ip to use for WebDriver server (default: 127.0.0.1)
+	    -p, --port <PORT>
+	            Port to use for WebDriver server (default: 4444)
+
 ## Building
 
 geckodriver is written in [Rust](https://www.rust-lang.org/)
@@ -327,14 +367,3 @@ ensure you do a compilation with optimisations:
 Or if you want a non-optimised binary for debugging:
 
     % cargo build
-
-## Usage
-
-Usage steps are [documented on MDN](https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver),
-but the gist of it is this:
-
-    % geckodriver -b /usr/bin/firefox
-
-Or if you’re on Mac:
-
-    % geckodriver -b /Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ by acting as a proxy between the local- and remote ends.
 
 You can consult the [change log](https://github.com/mozilla/geckodriver/blob/master/CHANGES.md)
 for a record of all notable changes to the program.
+[Releases](https://github.com/mozilla/geckodriver/releases)
+are made available on GitHub
+on [supported platforms](#supported-firefoxen).
 
 ## Supported Firefoxen
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,13 @@ We also keep track of known
 and [specification](https://github.com/mozilla/geckodriver/issues?q=is%3Aissue+is%3Aopen+label%3Aspec)
 problems in our issue tracker.
 
-Marionette support is best in Firefox 48 and onwards,
-although the more recent the Firefox version,
-the more bug fixes and features.
-**Firefox 47 is explicitly not supported.**
+Support is best in Firefox 48 and onwards,
+although generally the more recent the Firefox version,
+the better the experience as they have more bug fixes and features.
+We strongly advise using the [latest Firefox Nightly](https://nightly.mozilla.org/) with geckodriver,
+and want to make it clear that Firefox 47 and earlier is explicitly not supported.
+Since Windows XP support in Firefox will be dropped with Firefox 53,
+we do not support this platform.
 
 ## WebDriver capabilities
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,15 @@ Marionette and geckodriver are not yet feature complete.
 This means that they do not yet offer full conformance
 with the [WebDriver standard](https://w3c.github.io/webdriver/webdriver-spec.html)
 or complete compatibility with [Selenium](http://www.seleniumhq.org/).
-
 You can track the [implementation status](https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver/status)
-of the latest Firefox Nightly on MDN.
+of the latest [Firefox Nightly](http://whattrainisitnow.com/) on
+[MDN](https://developer.mozilla.org/).
 We also keep track of known
 [Marionette](https://github.com/mozilla/geckodriver/issues?q=is%3Aissue+is%3Aopen+label%3Amarionette),
 [Selenium](https://github.com/mozilla/geckodriver/issues?q=is%3Aissue+is%3Aopen+label%3Aselenium),
 and [specification](https://github.com/mozilla/geckodriver/issues?q=is%3Aissue+is%3Aopen+label%3Aspec)
-problems in our issue tracker.
+problems in our
+[issue tracker](https://github.com/mozilla/geckodriver/issues).
 
 Support is best in Firefox 48 and onwards,
 although generally the more recent the Firefox version,

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ This program provides the HTTP API described by
 the [WebDriver protocol](http://w3c.github.io/webdriver/webdriver-spec.html#protocol)
 to communicate with Gecko browsers, such as Firefox.
 It translates calls into
-the [Marionette](https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette)
-automation protocol
+the [Marionette automation protocol](https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette)
 by acting as a proxy between the local- and remote ends.
 
 You can consult the [change log](https://github.com/mozilla/geckodriver/blob/master/CHANGES.md)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ on [supported platforms](#supported-firefoxen).
 ## Supported Firefoxen
 
 Marionette and geckodriver are not yet feature complete.
-This means it does not yet offer full conformance
+This means that they do not yet offer full conformance
 with the [WebDriver standard](https://w3c.github.io/webdriver/webdriver-spec.html)
 or complete compatibility with [Selenium](http://www.seleniumhq.org/).
 


### PR DESCRIPTION
Various incremental improvements to the README to highlight we do not support Windows XP (see commit message), add some more links, and to expand a few sections.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/396)
<!-- Reviewable:end -->
