### PR TITLE
Improve firefox profile prefs merging:

### DIFF
--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -334,11 +334,12 @@ impl MarionetteHandler {
                          .map_err(|_| WebDriverError::new(ErrorStatus::UnknownError,
                                                           "Unable to read profile preferences file")));
 
-        prefs.insert("marionette.defaultPrefs.port", Pref::new(port as i64));
+        for &(ref name, ref value) in prefs::DEFAULT.iter() {
+            if !custom_profile || !prefs.contains_key(name) {
+                prefs.insert((*name).clone(), (*value).clone());
+            }
+        }
 
-        if !custom_profile {
-            prefs.insert_slice(&prefs::DEFAULT[..]);
-        };
         prefs.insert_slice(&extra_prefs[..]);
 
         prefs.insert_slice(&prefs::REQUIRED[..]);
@@ -346,6 +347,8 @@ impl MarionetteHandler {
         if let Some(ref level) = self.current_log_level {
             prefs.insert("marionette.logging", Pref::new(level.to_string()));
         };
+
+        prefs.insert("marionette.defaultPrefs.port", Pref::new(port as i64));
 
         prefs.write().map_err(|_| WebDriverError::new(ErrorStatus::UnknownError,
                                                       "Unable to write Firefox profile"))


### PR DESCRIPTION
- Merge prefs::Default prefs into custom profile unless the custom
  profile explicitly sets that preference.
- Set the marionette.defaultPrefs.port preference last so users cannot
  accidentally overwrite its value by providing it in capabilities.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/423)
<!-- Reviewable:end -->
