### PR TITLE
Use about:blank as new tab document

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 All notable changes to this program is documented in this file.
 
+## Unreleased
+
+### Changed
+- Now uses about:blank as the new tab document; this was previously disabled due to a bug in Marionette
+
 ## 0.14.0 (2017-01-31)
 
 ### Changed

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -30,11 +30,8 @@ lazy_static! {
         // Implicitly accept license
         ("browser.EULA.override", Pref::new(true)),
 
-        // Turn off once Marionette can correctly handle error pages,
-        // and does not hang when about:blank gets loaded twice
-        //
-        // (bug 1145668, 1312674)
-        ("browser.newtabpage.enabled", Pref::new(true)),
+        // use about:blank as new tab page
+        ("browser.newtabpage.enabled", Pref::new(false)),
 
         // Assume the about:newtab pages intro panels have been shown
         // to not depend on which test runs first and happens to open


### PR DESCRIPTION
Fixes: https://github.com/mozilla/geckodriver/issues/444

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/452)
<!-- Reviewable:end -->
