### PR TITLE
Avoid quitApplication when deleting session

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ All notable changes to this program is documented in this file.
 ## Unreleased
 
 ### Changed
+- geckodriver now responsible for terminating the Firefox process when the session ends
 - Now uses about:blank as the new tab document; this was previously disabled due to [bug 1333736](https://bugzilla.mozilla.org/show_bug.cgi?id=1333736) in Marionette
 
 ## 0.14.0 (2017-01-31)

--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -783,7 +783,9 @@ impl MarionetteCommand {
         }
     }
 
-    fn from_webdriver_message(id: u64, msg: &WebDriverMessage<GeckoExtensionRoute>) -> WebDriverResult<MarionetteCommand> {
+    fn from_webdriver_message(id: u64,
+                              msg: &WebDriverMessage<GeckoExtensionRoute>)
+                              -> WebDriverResult<MarionetteCommand> {
         let (opt_name, opt_parameters) = match msg.command {
             NewSession(ref x) => {
                 let mut data = BTreeMap::new();
@@ -791,11 +793,7 @@ impl MarionetteCommand {
                 data.insert("capabilities".to_string(), x.to_json());
                 (Some("newSession"), Some(Ok(data)))
             },
-            DeleteSession => {
-                let mut body = BTreeMap::new();
-                body.insert("flags".to_owned(), vec!["eForceQuit".to_json()].to_json());
-                (Some("quitApplication"), Some(Ok(body)))
-            },
+            DeleteSession => (Some("deleteSession"), None),
             Status => panic!("Got status command that should already have been handled"),
             Get(ref x) => (Some("get"), Some(x.to_marionette())),
             GetCurrentUrl => (Some("getCurrentUrl"), None),


### PR DESCRIPTION
The quitApplication command in Marionette instructs Firefox to terminate
itself and cannot be guaranteed to be race-free due to details of the
Firefox TCP socket imlementation.

Because geckodriver manages the lifetime of the Firefox session, it also
makes more sense for it to terminate the process when it is done with it.
It does this implicitly when Delete Session's response arrives.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/455)
<!-- Reviewable:end -->
