### PR TITLE
Don't send the eForceQuit flag when shutting down the session.

### DIFF
--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -793,7 +793,7 @@ impl MarionetteCommand {
             },
             DeleteSession => {
                 let mut body = BTreeMap::new();
-                body.insert("flags".to_owned(), vec!["eForceQuit".to_json()].to_json());
+                body.insert("flags".to_owned(), Json::Null);
                 (Some("quitApplication"), Some(Ok(body)))
             },
             Status => panic!("Got status command that should already have been handled"),


### PR DESCRIPTION
It turns out that marionette already adds an eAttemptQuit flag, and
passing both of these is wrong. We want a graceful shutdown if
possible, so don't add the force flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/461)
<!-- Reviewable:end -->
