### PR TITLE
Fix an error string for interpreting a cookie expiry as u64

### DIFF
--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -724,7 +724,7 @@ impl MarionetteSession {
                                         Ok(Date::new((try_opt!(
                                             x.as_u64(),
                                             ErrorStatus::UnknownError,
-                                            "Failed to interpret domain as String"))))
+                                            "Failed to interpret expiry as u64"))))
                                     }));
             let secure = try_opt!(
                 x.find("secure").map_or(Some(false), |x| x.as_boolean()),


### PR DESCRIPTION
This is a trivial copy-and-paste error from a few lines above.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/464)
<!-- Reviewable:end -->
