### PR TITLE
Fix for unpacking custom profiles ("corrupt deflate stream" exception)

### DIFF
--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -194,8 +194,10 @@ fn unzip_buffer(buf: &[u8], dest_dir: &Path) -> WebDriverResult<()> {
         if let Some(unzip_path) = unzip_path {
             debug!("Extracting profile to {}", unzip_path.to_string_lossy());
             let dest = try!(fs::File::create(unzip_path));
-            let mut writer = BufWriter::new(dest);
-            try!(io::copy(&mut file, &mut writer));
+            if file.size() > 0 {
+                let mut writer = BufWriter::new(dest);
+                try!(io::copy(&mut file, &mut writer));
+            }
         }
     }
 


### PR DESCRIPTION
I've encountered the issue #509 and noticed that it occurs only if there are empty files to process.
So I've decided to avoid processing of empty files and leave only their creation.

I suppose there is more beatiful fix, but mine is working for me well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/545)
<!-- Reviewable:end -->
