### PR TITLE
Change key stacktrace -> stackTrace in JSON repr

### DIFF
--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -1058,7 +1058,7 @@ impl MarionetteError {
             ErrorStatus::UnknownError,
             "Error message was not a string").into();
 
-        let stacktrace = match data.find("stacktrace") {
+        let stacktrace = match data.find("stackTrace") {
             None | Some(&Json::Null) => None,
             Some(x) => Some(try_opt!(x.as_string(),
                                      ErrorStatus::UnknownError,
@@ -1073,7 +1073,7 @@ impl ToJson for MarionetteError {
         let mut data = BTreeMap::new();
         data.insert("status".into(), self.status.to_json());
         data.insert("message".into(), self.message.to_json());
-        data.insert("stacktrace".into(), self.stacktrace.to_json());
+        data.insert("stackTrace".into(), self.stacktrace.to_json());
         Json::Object(data)
     }
 }


### PR DESCRIPTION
This seems to be the key expected by Selenium, see for example https://github.com/SeleniumHQ/selenium/blob/ceaf3da79542024becdda5953059dfbb96fb3a90/dotnet/src/webdriver/Remote/ErrorResponse.cs#L71 or https://github.com/SeleniumHQ/selenium/blob/7f7dc14143e0f59bac6245c921168d99150750ee/py/selenium/webdriver/remote/errorhandler.py#L173

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/547)
<!-- Reviewable:end -->
