### PR TITLE
Disable Flash and plugin container

### DIFF
--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -180,9 +180,13 @@ lazy_static! {
         // Make sure SNTP requests do not hit the network
         ("network.sntp.pools", Pref::new("%(server)s")),
 
+        // Disable Flash.  The plugin container it is run in is
+        // causing problems when quitting Firefox from geckodriver,
+        // c.f. https://github.com/mozilla/geckodriver/issues/225.
+        ("plugin.state.flash", Pref::new(0)),
+
         // Local documents have access to all other local docments,
         // including directory listings.
-
         ("security.fileuri.strict_origin_policy", Pref::new(false)),
 
         // Tests don't wait for the notification button security delay


### PR DESCRIPTION
In the interests of avoiding the

	Aborting on channel error.: file c:/builds/moz2_slave/m-rel-w32-00000000000000000000/build/src/ipc/glue/MessageChannel.cpp, line 2056

error we have seen frequently reported on geckodriver, this change forces
the Flash plugin to be disabled by default.  The Firefox homepage triggers
the plugin container to start, which is causing problems when quitting
Firefox through geckodriver.

Since Flash cannot be interacted with through WebDriver and it is soon
going away from the web, I don't think this is a big sacrifice.

Fixes: https://github.com/mozilla/geckodriver/issues/225

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/590)
<!-- Reviewable:end -->
