### PR TITLE
Update required Selenium version to 3.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ on [supported platforms](#supported-firefoxen).
 
 ## Supported Clients
 
-[Selenium](http://docs.seleniumhq.org/) users must update to [version 3.3](https://github.com/SeleniumHQ/selenium/releases/tag/selenium-3.3.0) or later to use geckodriver.
+[Selenium](http://docs.seleniumhq.org/) users must update to [version 3.3.1](https://github.com/SeleniumHQ/selenium/releases/tag/selenium-3.3.1) or later to use geckodriver.
 
 Other clients that follow the [W3C WebDriver specification](https://w3c.github.io/webdriver/webdriver-spec.html) are also supported.
 


### PR DESCRIPTION
Hi,
in recent days we get a few bugreports in [facebook/php-webdriver](https://github.com/facebook/php-webdriver) project from people trying to use Selenium 3.3.0 with latest geckodriver (like https://github.com/facebook/php-webdriver/issues/432 and https://github.com/facebook/php-webdriver/issues/434). However version 3.3.0 of Selenium is affected with some incompatibilities (eg. https://github.com/SeleniumHQ/selenium/issues/3632), so I suggest clearly recommending version 3.3.1+.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/593)
<!-- Reviewable:end -->
