### PR TITLE
Set marionette.port in profile

### DIFF
--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -357,6 +357,8 @@ impl MarionetteHandler {
             prefs.insert("marionette.logging", Pref::new(level.to_string()));
         };
 
+        // fallback can be removed when Firefox 54 becomes stable
+        prefs.insert("marionette.port", Pref::new(port as i64));
         prefs.insert("marionette.defaultPrefs.port", Pref::new(port as i64));
 
         prefs.write().map_err(|_| WebDriverError::new(ErrorStatus::UnknownError,


### PR DESCRIPTION
The marionette.defaultPrefs.port preference
has been renamed to marionette.port as part of
https://bugzilla.mozilla.org/show_bug.cgi?id=1344748.

We keep the fallback preference around until Firefox 54 becomes stable
for backwards compatibility reasons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/599)
<!-- Reviewable:end -->
