### PR TITLE
Remove capabilities field wrapping for NewSession

### DIFF
--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -832,17 +832,17 @@ impl MarionetteCommand {
         let (opt_name, opt_parameters) = match msg.command {
             NewSession(_) => {
                 let caps = capabilities.expect("Tried to create new session without processing capabilities");
+
                 let mut data = BTreeMap::new();
-                data.insert("sessionId".to_string(), Json::Null);
-                let mut capabilites = BTreeMap::new();
-                for (key, value) in caps.iter() {
-                    capabilites.insert(key.to_string(), value.to_json());
+                for (k, v) in caps.iter() {
+                    data.insert(k.to_string(), v.to_json());
                 }
-                // Copy into a desiredCapabilities key for legacy compat.
-                capabilites.insert("desiredCapabilities".to_string(),
-                                   caps.to_json());
-                data.insert("capabilities".to_string(),
-                            capabilites.to_json());
+
+                // duplicate in capabilities.desiredCapabilities for legacy compat
+                let mut legacy_caps = BTreeMap::new();
+                legacy_caps.insert("desiredCapabilities".to_string(), caps.to_json());
+                data.insert("capabilities".to_string(), legacy_caps.to_json());
+
                 (Some("newSession"), Some(Ok(data)))
             },
             DeleteSession => {


### PR DESCRIPTION
Remove one layer of wrapping inside the `capabilities' field when
geckodriver sends the capabilities to Marionette.

Prior to this patch, geckodriver would send the following JSON Object
to Marionette's newSession command:

	{capabilities: {foo: 1, {desiredCapabilities: {foo: 1}}}}

Following this patch, it sends:

	{foo: 1, {capabilities: {desiredCapabilities: {foo: 1}}}}

In the future, the idea is to remove the capabilities object altogether
and just send

	{foo: 1}

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/603)
<!-- Reviewable:end -->
