### PR TITLE
Set marionette.log.level pref

### DIFF
--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -351,13 +351,13 @@ impl MarionetteHandler {
 
         prefs.insert_slice(&extra_prefs[..]);
 
+        // fallbacks can be removed when Firefox 54 becomes stable
         if let Some(ref level) = self.current_log_level {
-            prefs.insert("marionette.logging", Pref::new(level.to_string()));
+            prefs.insert("marionette.log.level", Pref::new(level.to_string()));
+            prefs.insert("marionette.logging", Pref::new(level.to_string()));  // fallback
         };
-
-        // fallback can be removed when Firefox 54 becomes stable
         prefs.insert("marionette.port", Pref::new(port as i64));
-        prefs.insert("marionette.defaultPrefs.port", Pref::new(port as i64));
+        prefs.insert("marionette.defaultPrefs.port", Pref::new(port as i64));  // fallback
 
         prefs.write().map_err(|_| WebDriverError::new(ErrorStatus::UnknownError,
                                                       "Unable to write Firefox profile"))


### PR DESCRIPTION
marionette.logging has been renamed marionette.log.level, but we keep
the former around for backwards compatibility with earlier Firefoxen.

This is similar to change made in 8f19dc4dac63da4153584a2a6974c26be9453ecc
for marionette.port.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/604)
<!-- Reviewable:end -->
