### PR TITLE
Send text string and value array for SendKeysParameters

### DIFF
--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -914,7 +914,13 @@ impl MarionetteCommand {
             ElementSendKeys(ref e, ref x) => {
                 let mut data = BTreeMap::new();
                 data.insert("id".to_string(), e.id.to_json());
-                data.insert("value".to_string(), x.text.to_json());
+                data.insert("text".to_string(), x.text.to_json());
+                data.insert("value".to_string(),
+                            x.text
+                                .chars()
+                                .map(|x| x.to_string())
+                                .collect::<Vec<String>>()
+                                .to_json());
                 (Some("sendKeysToElement"), Some(Ok(data)))
             },
             ExecuteScript(ref x) => (Some("executeScript"), Some(x.to_marionette())),
@@ -932,7 +938,13 @@ impl MarionetteCommand {
             GetAlertText => (Some("getTextFromDialog"), None),
             SendAlertText(ref x) => {
                 let mut data = BTreeMap::new();
-                data.insert("value".to_string(), x.text.to_json());
+                data.insert("text".to_string(), x.text.to_json());
+                data.insert("value".to_string(),
+                            x.text
+                                .chars()
+                                .map(|x| x.to_string())
+                                .collect::<Vec<String>>()
+                                .to_json());
                 (Some("sendKeysToDialog"), Some(Ok(data)))
             },
             TakeScreenshot => {


### PR DESCRIPTION
Following https://bugzilla.mozilla.org/show_bug.cgi?id=1348782
and https://bugzilla.mozilla.org/show_bug.cgi?id=1354323, the
sendKeysToElement and sendKeysToDialog commands in Marionette accept
only a string `text' field as input.

These patches to Firefox has since been uplifted all the way to Firefox
53.  In order to make geckodriver work with newer Firefox versions again,
we need to pass the `text' field.  But in order to support older Firefoxen
without the `text' field requirement, we also want to continue to send
`value' as a string array.

Clients must unfortunately send a string `text' field, but it is believed
it is easier to upgrade to the latest Selenium release than to pin the
exact versions of geckodriver and Firefox.

Fixes: https://github.com/mozilla/geckodriver/issues/594

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/612)
<!-- Reviewable:end -->
