### PR TITLE
Document default profile in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,9 @@ and may contain any of the following fields:
    to use as the profile for the Firefox instance.
    This may be used to e.g. install extensions
    or custom certificates.
+   By default, a new profile will be created in the system’s temporary folder.
+   The effective profile in use by the WebDriver session
+   is returned to the user in the `moz:profile` capability.
  </tr>
 
  <tr>


### PR DESCRIPTION
Add documentation that explains where the fresh profiles are created
and how you can get its path from the returned capabilities object.

Fixes: https://github.com/mozilla/geckodriver/issues/605

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/627)
<!-- Reviewable:end -->
