### PR TITLE
acceptInsecureCerts works on Firefox 52.

### DIFF
--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -106,7 +106,7 @@ impl<'a> BrowserCapabilities for FirefoxCapabilities<'a> {
     fn accept_insecure_certs(&mut self, _: &Capabilities) -> WebDriverResult<bool> {
         let version_str = try!(self.version().or_else(|x| Err(convert_version_error(x))));
         if let Some(x) = version_str {
-            Ok(try!(Version::from_str(&*x).or_else(|x| Err(convert_version_error(x)))).major > 52)
+            Ok(try!(Version::from_str(&*x).or_else(|x| Err(convert_version_error(x)))).major >= 52)
         } else {
             Ok(false)
         }


### PR DESCRIPTION
Fixes #630.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/632)
<!-- Reviewable:end -->
