### PR TITLE
Reduce and harmonise logging

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -127,14 +127,14 @@ struct GeckoFormat;
 
 impl Format for GeckoFormat {
     fn format(&self, io: &mut io::Write, record: &Record, _: &OwnedKeyValueList) -> io::Result<()> {
-        let ts = format_ts(Local::now());
-        let level = record.level().to_gecko();
-        let _ = try!(write!(io,
-                            "{}\t{}\t{}\t{}\n",
-                            ts,
-                            record.module(),
-                            level,
-                            record.msg()));
+        // TODO(ato): Quite sure this is the wrong way to filter records with slog,
+        // but I do not comprehend how slog works.
+        let module = record.module();
+        if module.starts_with("geckodriver") || module.starts_with("webdriver") {
+            let ts = format_ts(Local::now());
+            let level = record.level().to_gecko();
+            let _ = try!(write!(io, "{}\t{}\t{}\t{}\n", ts, module, level, record.msg()));
+        }
         Ok(())
     }
 }

--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -1138,7 +1138,6 @@ impl MarionetteConnection {
         let poll_attempts = timeout / poll_interval;
         let mut poll_attempt = 0;
 
-        info!("Connecting to Marionette on {}:{}", DEFAULT_HOST, self.port);
         loop {
             match TcpStream::connect(&(DEFAULT_HOST, self.port)) {
                 Ok(stream) => {
@@ -1146,7 +1145,7 @@ impl MarionetteConnection {
                     break
                 },
                 Err(e) => {
-                    debug!("  connection attempt {}/{}", poll_attempt, poll_attempts);
+                    trace!("  connection attempt {}/{}", poll_attempt, poll_attempts);
                     if poll_attempt <= poll_attempts {
                         poll_attempt += 1;
                         sleep(Duration::from_millis(poll_interval));
@@ -1158,7 +1157,7 @@ impl MarionetteConnection {
             }
         };
 
-        debug!("TCP connection established");
+        debug!("Connected to Marionette on {}:{}", DEFAULT_HOST, self.port);
 
         try!(self.handshake());
         Ok(())
@@ -1213,7 +1212,7 @@ impl MarionetteConnection {
 
     fn send(&mut self, msg: Json) -> WebDriverResult<String> {
         let data = self.encode_msg(msg);
-        debug!("→ {}", data);
+        trace!("→ {}", data);
 
         match self.stream {
             Some(ref mut stream) => {
@@ -1287,7 +1286,7 @@ impl MarionetteConnection {
 
         // TODO(jgraham): Need to handle the error here
         let data = String::from_utf8(payload).unwrap();
-        debug!("← {}", data);
+        trace!("← {}", data);
 
         Ok(data)
     }


### PR DESCRIPTION
Filters out all hyper-related log messages, which are essentially useless to us, and reduces the log level importance of Marionette protocol chatter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/636)
<!-- Reviewable:end -->
