### PR TITLE
Append X11 style -marionette flag when starting browser

### DIFF
--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -314,6 +314,10 @@ impl MarionetteHandler {
         let mut runner = try!(FirefoxRunner::new(&binary, options.profile.take())
                               .map_err(|e| WebDriverError::new(ErrorStatus::SessionNotCreated,
                                                                e.description().to_owned())));
+
+        // double-dashed flags are not accepted on Windows systems
+        runner.args().push("-marionette");
+
         if let Some(args) = options.args.take() {
             runner.args().extend(args);
         };


### PR DESCRIPTION
https://github.com/jgraham/rust_mozrunner/pull/7 was recently submitted
to make mozrunner not imply starting the Marionette server by passing the
--marionette flag.  This patch appends -marionette, with a single dash,
so that it will be accepted on Windows systems.

More discussion around this in
https://github.com/mozilla/geckodriver/commit/2e0054b90ecf1acbe8b442af54441e3cc746933f.

Fixes: https://github.com/mozilla/geckodriver/issues/640

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/641)
<!-- Reviewable:end -->
