### PR TITLE
Accept "page load" as an alternative spelling of "pageLoad" in the Ge…

### DIFF
--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -557,8 +557,10 @@ impl MarionetteSession {
                                           .as_u64(),
                                       ErrorStatus::UnknownError,
                                       "Failed to interpret script timeout duration as u64");
-                let page_load = try_opt!(try_opt!(resp.result
-                                                      .find("pageLoad"),
+                // Check for the spec-compliant "pageLoad", but also for "page load",
+                // which was sent by Firefox 52 and earlier.
+                let page_load = try_opt!(try_opt!(resp.result.find("pageLoad")
+                                                      .or(resp.result.find("page load")),
                                                   ErrorStatus::UnknownError,
                                                   "Missing field: pageLoad")
                                              .as_u64(),


### PR DESCRIPTION
…t Timeouts response.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/656)
<!-- Reviewable:end -->
