### PR TITLE
Permit Json::U64 when validating prefs in moz:firefoxOptions.

### DIFF
--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -189,7 +189,7 @@ impl<'a> BrowserCapabilities for FirefoxCapabilities<'a> {
                                                     ErrorStatus::InvalidArgument,
                                                     "prefs value is not an object");
                             if !prefs_data.values()
-                                .all(|x| x.is_string() || x.is_i64() || x.is_boolean()) {
+                                .all(|x| x.is_string() || x.is_i64() || x.is_u64() || x.is_boolean()) {
                                     return Err(WebDriverError::new(
                                         ErrorStatus::InvalidArgument,
                                         "Preference values not all string or integer or boolean"));


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/658)
<!-- Reviewable:end -->
