### PR TITLE
Unmarshal CloseWindowResponse

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 All notable changes to this program is documented in this file.
 
+## Unreleased
+
+### Fixed
+- Session is now ended when closing the last Firefox window (fixes [#613](https://github.com/mozilla/geckodriver/issues/613))
+
 ## v0.16.0 (2016-04-21)
 
 Note that geckodriver v0.16.0 is only compatible with Selenium 3.4 and greater.

--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -40,8 +40,8 @@ use webdriver::command::{
     SwitchToFrameParameters, LocatorParameters, JavascriptCommandParameters,
     GetNamedCookieParameters, AddCookieParameters, TimeoutsParameters,
     ActionsParameters, TakeScreenshotParameters};
-use webdriver::response::{Cookie, CookieResponse, ElementRectResponse, NewSessionResponse,
-                          TimeoutsResponse, ValueResponse, WebDriverResponse,
+use webdriver::response::{CloseWindowResponse, Cookie, CookieResponse, ElementRectResponse,
+                          NewSessionResponse, TimeoutsResponse, ValueResponse, WebDriverResponse,
                           WindowRectResponse};
 use webdriver::common::{
     Date, Nullable, WebElement, FrameId, ELEMENT_KEY};
@@ -528,8 +528,8 @@ impl MarionetteSession {
         try!(self.update(msg, &resp));
 
         Ok(match msg.command {
-            //Everything that doesn't have a response value
-            Get(_) | GoBack | GoForward | Refresh | CloseWindow | SetTimeouts(_) |
+            // Everything that doesn't have a response value
+            Get(_) | GoBack | GoForward | Refresh | SetTimeouts(_) |
             SetWindowRect(_) | MaximizeWindow | SwitchToWindow(_) | SwitchToFrame(_) |
             SwitchToParentFrame | AddCookie(_) | DeleteCookies | DeleteCookie(_) |
             DismissAlert | AcceptAlert | SendAlertText(_) | ElementClick(_) |
@@ -537,7 +537,7 @@ impl MarionetteSession {
             PerformActions(_) | ReleaseActions => {
                 WebDriverResponse::Void
             },
-            //Things that simply return the contents of the marionette "value" property
+            // Things that simply return the contents of the marionette "value" property
             GetCurrentUrl | GetTitle | GetPageSource | GetWindowHandle | IsDisplayed(_) |
             IsSelected(_) | GetElementAttribute(_, _) | GetElementProperty(_, _) |
             GetCSSValue(_, _) | GetElementText(_) |
@@ -584,6 +584,20 @@ impl MarionetteSession {
             GetWindowHandles => {
                 WebDriverResponse::Generic(ValueResponse::new(resp.result.clone()))
             },
+            CloseWindow => {
+                let data = try_opt!(resp.result.as_array(),
+                                    ErrorStatus::UnknownError,
+                                    "Failed to interpret value as array");
+                let handles = try!(data.iter()
+                                       .map(|x| {
+                                                Ok(try_opt!(x.as_string(),
+                                                            ErrorStatus::UnknownError,
+                                                            "Failed to interpret window handle as string")
+                                                           .to_owned())
+                                            })
+                                       .collect());
+                WebDriverResponse::CloseWindow(CloseWindowResponse { window_handles: handles })
+            }
             GetWindowRect => {
                 let width = try_opt!(
                     try_opt!(resp.result.find("width"),


### PR DESCRIPTION
geckodriver currently assumes the response from the CloseWindow command
is empty and unmarshals it to Ok(Void).

Starting with Firefox 52, Marionette returns a window handle array to
indicate whether the last window was closed.  If this array is empty,
the delete_session field is set to true and the session is ended.

Fixes: https://github.com/mozilla/geckodriver/issues/613

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/678)
<!-- Reviewable:end -->
