### PR TITLE
Possible fix for Linux 32-bit release build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ matrix:
       addons:
         apt:
           packages: &i686
+          - musl:i386
+          - musl-dev
           - musl-tools
           - gcc-multilib
           - libbz2-dev


### PR DESCRIPTION
After more testing, I believe musl:i386 may need to be explicitly defined, although it should be a dep from musl-tools.  The travis environment may be having an issue here.
Testing travis build via this pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/698)
<!-- Reviewable:end -->
