### PR TITLE
v0.16.2 linux32 explicit musl*:i386 packages for optimized build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ matrix:
       addons:
         apt:
           packages: &i686
+          - musl:i386
+          - musl-dev
           - musl-tools
           - gcc-multilib
           - libbz2-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,8 @@ matrix:
         apt:
           packages: &i686
           - musl:i386
-          - musl-dev
-          - musl-tools
+          - musl-dev:i386
+          - musl-tools:i386
           - gcc-multilib
           - libbz2-dev
     - os: linux


### PR DESCRIPTION
The 32-bit optimized build failure seems to be a travis build environment issue caused by backtrace-sys calling snprintf here:
https://github.com/alexcrichton/backtrace-rs/blob/master/backtrace-sys/src/libbacktrace/dwarf.c

Travis is building with Ubuntu amd64 musl packages, and __snprintf_chk can't be found when optimizing for 32-bit systems.

This may fix the /usr/bin/ld-musl-config musl package conflict between the amd64 and i386 packages.  (Testing travis builds via pull request).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/699)
<!-- Reviewable:end -->
