### PR TITLE
Correct error when there is no current session

### DIFF
--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -397,7 +397,7 @@ impl WebDriverHandler<GeckoExtensionRoute> for MarionetteHandler {
                             },
                             _ => {
                                 return Err(WebDriverError::new(
-                                    ErrorStatus::UnknownError,
+                                    ErrorStatus::SessionNotCreated,
                                     "Tried to run command without establishing a connection"));
                             }
                         }


### PR DESCRIPTION
Fixes: https://github.com/mozilla/geckodriver/issues/689

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/701)
<!-- Reviewable:end -->
