### PR TITLE
Updated .travis.yml for linux32 optimized compile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,13 @@ cache:
     - $HOME/.cargo
     - $TRAVIS_BUILD_DIR/target
     - $HOME/docker/
-
+    
+before_install:
+  - if [[ "$NAME" == "linux32" ]]; then
+    sudo dpkg --purge build-essential libtool;
+    sudo apt-get -qq update;
+    sudo apt-get -yq --force-yes install libstdc++6:i386 libbz2-dev:i386 gcc-multilib:i386 musl-tools:i386; fi
+    
 matrix:
   include:
     - os: linux
@@ -35,15 +41,8 @@ matrix:
         - TARGET=i686-unknown-linux-musl
         - NAME=linux32
         - EXT=tar.gz
-        - CC=gcc
       dist: trusty
       sudo: required
-      addons:
-        apt:
-          packages: &i686
-          - musl-tools
-          - gcc-multilib
-          - libbz2-dev
     - os: linux
       env:
         - TARGET=x86_64-pc-windows-gnu


### PR DESCRIPTION
Added "before_install" to handle packages/deps that solve the current 32-bit Linux optimized release errors.
This addition also ensures future changes in dependencies like backtrace-sys won't cause similar issues.
Defining OS for the i686 target is no longer needed and will break the build if defined.

If the build fails, please clear the cache per: https://docs.travis-ci.com/user/caching/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/704)
<!-- Reviewable:end -->
