### PR TITLE
Make trace logs safe for windows prompt

### DIFF
--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -1352,7 +1352,7 @@ impl MarionetteConnection {
 
     fn send(&mut self, msg: Json) -> WebDriverResult<String> {
         let data = self.encode_msg(msg);
-        trace!("→ {}", data);
+        trace!("-> {}", data);
 
         match self.stream {
             Some(ref mut stream) => {
@@ -1426,7 +1426,7 @@ impl MarionetteConnection {
 
         // TODO(jgraham): Need to handle the error here
         let data = String::from_utf8(payload).unwrap();
-        trace!("← {}", data);
+        trace!("<- {}", data);
 
         Ok(data)
     }


### PR DESCRIPTION
The symbols "←" and "→" are encodeed as "?" in the Windows command
prompt.  To make the logs from this system useful, use ASCII versions
of the arrows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/722)
<!-- Reviewable:end -->
