### PR TITLE
Upgrade docker image to Ubuntu 16.04 LTS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ matrix:
         - NAME=win32
         - EXT=zip
         - TOOLCHAIN=nightly
-        - DOCKER_IMAGE=i686-trusty
+        - DOCKER_IMAGE=i686-xenial
       dist: trusty
       services:
         - docker

--- a/i686-xenial/Dockerfile
+++ b/i686-xenial/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:15.10
+FROM ubuntu:16.04
 
 RUN apt-get -y update
 RUN apt-get -y install curl file gcc gcc-mingw-w64-i686 zip


### PR DESCRIPTION
@andreastt do you have an idea why we execute package installation commands in parallel? Maybe there was already such a problem in the past?

https://travis-ci.org/mozilla/geckodriver/jobs/396587079

If we can get this fixed we only have to figure out why the job initially hangs for Windows 64:
https://travis-ci.org/mozilla/geckodriver/jobs/396587080

Everything else seems to work including the build of the win32 binary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/1311)
<!-- Reviewable:end -->
