### PR TITLE
fix marionette link

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ the built executable with `./mach geckodriver -- --other --flags`.
 [Marionette protocol]: https://firefox-source-docs.mozilla.org/testing/marionette/marionette/Protocol.html
 [WebDriver]: https://w3c.github.io/webdriver/webdriver-spec.html
 [FirefoxDriver]: https://github.com/SeleniumHQ/selenium/wiki/FirefoxDriver
-[Marionette]: https://firefox-source-docs.mozilla.org/testing/marionette/marionette/
+[Marionette]: https://firefox-source-docs.mozilla.org/testing/marionette/doc/marionette/index.html
 [Firefox CI]: https://treeherder.mozilla.org/
 [mozconfig]: https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Configuring_Build_Options
 


### PR DESCRIPTION
led to 404 page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/geckodriver/1323)
<!-- Reviewable:end -->
